### PR TITLE
Fixed logging of instruction pointer in Get/SetContextThread hooks.

### DIFF
--- a/hook_thread.c
+++ b/hook_thread.c
@@ -227,9 +227,9 @@ HOOKDEF(NTSTATUS, WINAPI, NtGetContextThread,
     NTSTATUS ret = Old_NtGetContextThread(ThreadHandle, Context);
 	if (Context->ContextFlags & CONTEXT_CONTROL)
 #ifdef _WIN64
-		LOQ_ntstatus("threading", "pp", "ThreadHandle", ThreadHandle, "InstructionPointer", Context->Rip);
+		LOQ_ntstatus("threading", "pp", "ThreadHandle", ThreadHandle, "InstructionPointer", Context->Rcx);
 #else
-		LOQ_ntstatus("threading", "pp", "ThreadHandle", ThreadHandle, "InstructionPointer", Context->Eip);
+		LOQ_ntstatus("threading", "pp", "ThreadHandle", ThreadHandle, "InstructionPointer", Context->Eax);
 #endif
 	else
 		LOQ_ntstatus("threading", "p", "ThreadHandle", ThreadHandle);
@@ -248,9 +248,9 @@ HOOKDEF(NTSTATUS, WINAPI, NtSetContextThread,
 	ret = Old_NtSetContextThread(ThreadHandle, Context);
 	if (Context->ContextFlags & CONTEXT_CONTROL)
 #ifdef _WIN64
-		LOQ_ntstatus("threading", "pp", "ThreadHandle", ThreadHandle, "InstructionPointer", Context->Rip);
+		LOQ_ntstatus("threading", "pp", "ThreadHandle", ThreadHandle, "InstructionPointer", Context->Rcx);
 #else
-		LOQ_ntstatus("threading", "pp", "ThreadHandle", ThreadHandle, "InstructionPointer", Context->Eip);
+		LOQ_ntstatus("threading", "pp", "ThreadHandle", ThreadHandle, "InstructionPointer", Context->Eax);
 #endif
 	else
 		LOQ_ntstatus("threading", "p", "ThreadHandle", ThreadHandle);


### PR DESCRIPTION
The registers used to store the entry point instruction pointer for a new (suspended) process using the Set/GetContextThread APIs are EAX and RCX for 32/64 bit respectively. This change fixes the 'Instruction Pointer' log output for these API hooks to show the correct entry point for a new process.